### PR TITLE
Allow custom base branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The config file looks like:
 
 ```yaml
 current_version: "201910.1.0"
+base_branch: "master"
 strategy:
   name: "calver"
   part: "minor"
@@ -67,6 +68,7 @@ tracked_files:
 
 where:
 * `current_version` - the current version of your files. It needs to be wrapped in quotes to force parsing to be string (e.g. avoid calver current_version to be parsed as float)
+* `base_branch` - The name of base branch in the repository. Default value is `master` if it is not specified.
 * `strategy` - strategy section
    * `name` - supported values: `semver`, `calver`
    * `part` - the target part to update when `bumpit` runs. Please refer to the description below for strategy specific values.

--- a/bumpit/core/bumpit.py
+++ b/bumpit/core/bumpit.py
@@ -53,6 +53,7 @@ class BumpIt:
         )
         self._current_version = configuration.current_version
         self._tracked_files = configuration.tracked_files + [configuration.config_file]
+        self._base_branch = configuration.base_branch
 
     def execute(self, bumped_version):
         self._folder_manager.update(
@@ -62,5 +63,7 @@ class BumpIt:
         )
 
         self._vcs.update(
-            current_version=self._current_version, bumped_version=bumped_version
+            current_version=self._current_version,
+            bumped_version=bumped_version,
+            base_branch=self._base_branch,
         )

--- a/bumpit/core/config/__init__.py
+++ b/bumpit/core/config/__init__.py
@@ -16,6 +16,7 @@ class Configuration:
     tag: Tag
     auto_remote_push: bool
     tracked_files: list
+    base_branch: str
 
     @staticmethod
     def parse(file):
@@ -30,6 +31,9 @@ class Configuration:
         contents["commit"] = Commit.load(contents["commit"])
         contents["tag"] = Tag.load(contents["tag"])
         contents["config_file"] = file
+
+        if contents.get("base_branch") is None:
+            contents["base_branch"] = "master"
 
         return Configuration(**contents)
 

--- a/bumpit/core/vcs.py
+++ b/bumpit/core/vcs.py
@@ -20,10 +20,10 @@ class Git:
         self._logger = logger
         self._command_executor = command_executor or os.system
 
-    def update(self, current_version, bumped_version):
+    def update(self, current_version, bumped_version, base_branch):
         self._git_commit(current_version, bumped_version)
         self._git_tag(current_version, bumped_version)
-        self._git_push()
+        self._git_push(base_branch)
 
     def _git_commit(self, current_version, bumped_version):
         self._execute_command("git add .")
@@ -46,9 +46,9 @@ class Git:
 
         self._execute_command(tag_command)
 
-    def _git_push(self):
+    def _git_push(self, base_branch):
         if self._auto_remote_push:
-            return self._execute_command("git push origin master --tags")
+            return self._execute_command(f"git push origin {base_branch} --tags")
         else:
             self._logger.info("Skipped pushing changes to remote...")
 

--- a/tests/fixtures/config/.bumpit-custom-base.yaml
+++ b/tests/fixtures/config/.bumpit-custom-base.yaml
@@ -1,0 +1,13 @@
+current_version: "0.0.1"
+base_branch: "main"
+strategy:
+  name: "semver"
+  part: "minor"
+commit:
+  author: "Homer Simpson <homer@simpson.com>"
+tag:
+  apply: True
+  format: "{version}"
+auto_remote_push: False
+tracked_files:
+  - setup.py

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -16,6 +16,7 @@ class TestConfig:
         assert config.tag.format == "{version}"
         assert config.auto_remote_push is False
         assert config.tracked_files == ["setup.py", "sample/VERSION"]
+        assert config.base_branch == "master"
 
     def test_config_calver(self):
         config_file = fixture_path("config/.bumpit-calver.yaml")
@@ -30,6 +31,21 @@ class TestConfig:
         assert config.tag.format == "{version}"
         assert config.auto_remote_push is False
         assert config.tracked_files == ["setup.py", "sample/VERSION"]
+        assert config.base_branch == "master"
+
+    def test_config_custom_base_branch(self):
+        config_file = fixture_path("config/.bumpit-custom-base.yaml")
+        config = Configuration.parse(file=config_file)
+
+        assert config.base_branch == "main"
+        assert config.config_file == config_file
+        assert config.current_version == "0.0.1"
+        assert config.strategy.name == "semver"
+        assert config.strategy.part == "minor"
+        assert config.tag.apply
+        assert config.tag.format == "{version}"
+        assert config.auto_remote_push is False
+        assert config.tracked_files == ["setup.py"]
 
     def test_config_missing_fields(self):
         with pytest.raises(ValueError):

--- a/tests/unit/core/test_vcs.py
+++ b/tests/unit/core/test_vcs.py
@@ -23,6 +23,7 @@ class TestGit:
         self._command_executor = CommandExecutorSpy()
         self._current_version = "0.0.0"
         self._bumped_version = "1.0.0"
+        self._base_branch = "main"
 
         self._settings = GitSettings(
             author="A B <a@b.com>",
@@ -38,7 +39,7 @@ class TestGit:
             logger=self._logger_spy,
             command_executor=self._command_executor,
         )
-        git.update(self._current_version, self._bumped_version)
+        git.update(self._current_version, self._bumped_version, self._base_branch)
 
         assert self._command_executor.call_count == 0
         assert [
@@ -56,7 +57,7 @@ class TestGit:
             logger=self._logger_spy,
             command_executor=self._command_executor,
         )
-        git.update(self._current_version, self._bumped_version)
+        git.update(self._current_version, self._bumped_version, self._base_branch)
 
         assert [
             "git add .",
@@ -80,7 +81,7 @@ class TestGit:
             logger=self._logger_spy,
             command_executor=self._command_executor,
         )
-        git.update(self._current_version, self._bumped_version)
+        git.update(self._current_version, self._bumped_version, self._base_branch)
 
         assert self._command_executor.call_count == 0
         assert [
@@ -103,7 +104,7 @@ class TestGit:
             logger=self._logger_spy,
             command_executor=self._command_executor,
         )
-        git.update(self._current_version, self._bumped_version)
+        git.update(self._current_version, self._bumped_version, self._base_branch)
 
         assert self._command_executor.call_count == 0
         assert [
@@ -111,7 +112,7 @@ class TestGit:
             "[DRY-RUN] Ran `git commit --author 'A B <a@b.com>' "
             "-m 'Bumped version from 0.0.0 → 1.0.0.'`",
             "Skipped tagging...",
-            "[DRY-RUN] Ran `git push origin master --tags`",
+            "[DRY-RUN] Ran `git push origin main --tags`",
         ] == self._logger_spy.messages
 
     def test_invalid_tag_format(self):
@@ -135,4 +136,4 @@ class TestGit:
             command_executor=command_executor,
         )
         with pytest.raises(Exception):
-            git.update(self._current_version, self._bumped_version)
+            git.update(self._current_version, self._bumped_version, self._base_branch)


### PR DESCRIPTION
Allow custom base branch name other than `master`

The default value of `base_branch` is `master` when it is not specified.